### PR TITLE
TP5-2do, TP6 y TP7 Dockerfile (Actualizados) Commit

### DIFF
--- a/56011.Bernard.Juan/05-trabajo-2do/Dockerfile
+++ b/56011.Bernard.Juan/05-trabajo-2do/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3
+
+RUN git clone https://github.com/JuaniBernard/05-trabajo-2do.git
+
+WORKDIR /05-trabajo-2do
+
+RUN pip install parameterized
+
+CMD ["python3", "test_producto.py"]

--- a/56011.Bernard.Juan/06-trabajo/Dockerfile
+++ b/56011.Bernard.Juan/06-trabajo/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3
+
+RUN git clone https://github.com/JuaniBernard/06-trabajo.git
+
+WORKDIR /06-trabajo
+
+RUN pip install parameterized
+
+CMD ["python3", "test_producto.py"]

--- a/56011.Bernard.Juan/07-trabajo/Dockerfile
+++ b/56011.Bernard.Juan/07-trabajo/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3
+
+RUN git clone https://github.com/JuaniBernard/07-trabajo.git
+
+WORKDIR /07-trabajo
+
+RUN pip install parameterized
+
+CMD ["python3", "test_producto.py"]


### PR DESCRIPTION
Agrego los Dockerfiles del TP5 (dice 2do porque el semestre pasado subí otro TP5) y del TP6. Está actualizada la pull request, ya que la anterior tenía conflictos y tuve que clonar el repositorio 2020.01 otra vez.